### PR TITLE
comparing to reportgenerator tool

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -51,3 +51,36 @@ jobs:
 
     - name: Write to Job Summary
       run: cat code-coverage-results.md >> $GITHUB_STEP_SUMMARY
+
+  build-reportgenerator:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: 6.0.x
+        
+    - name: Restore dependencies
+      run: dotnet restore
+      
+    - name: Build
+      run: dotnet build --no-restore
+      
+    # Add coverlet.collector nuget package to test project - 'dotnet add <TestProject.cspoj> package coverlet
+    - name: Test
+      run: dotnet test --no-build --verbosity normal --collect:"XPlat Code Coverage" --logger trx --results-directory coverage
+      
+    - name: Copy Coverage To Predictable Location
+      run: cp coverage/*/coverage.cobertura.xml coverage/coverage.cobertura.xml
+
+    - name: Create code coverage report
+      run: |
+        dotnet tool install -g dotnet-reportgenerator-globaltool
+        reportgenerator -reports:coverage/coverage.cobertura.xml -targetdir:CodeCoverage -reporttypes:'MarkdownSummaryGithub;Cobertura'
+
+    - name: Write to Job Summary
+      run: cat CodeCoverage/SummaryGithub.md >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -73,14 +73,11 @@ jobs:
     # Add coverlet.collector nuget package to test project - 'dotnet add <TestProject.cspoj> package coverlet
     - name: Test
       run: dotnet test --no-build --verbosity normal --collect:"XPlat Code Coverage" --logger trx --results-directory coverage
-      
-    - name: Copy Coverage To Predictable Location
-      run: cp coverage/*/coverage.cobertura.xml coverage/coverage.cobertura.xml
 
     - name: Create code coverage report
       run: |
         dotnet tool install -g dotnet-reportgenerator-globaltool
-        reportgenerator -reports:coverage/coverage.cobertura.xml -targetdir:CodeCoverage -reporttypes:'MarkdownSummaryGithub;Cobertura'
+        reportgenerator -reports:**/coverage.cobertura.xml -targetdir:CodeCoverage -reporttypes:'MarkdownSummaryGithub;Cobertura'
 
     - name: Write to Job Summary
       run: cat CodeCoverage/SummaryGithub.md >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
Using the `reportgenerator` tool to generate code coverage and publish to the job summary report.

This is a comparison between using the [irongut/CodeCoverageSummary](https://github.com/irongut/CodeCoverageSummary) action (top) and [reportgenerator](https://reportgenerator.io/usage) (bottom): 

<img src="https://github.com/joshjohanning/joshjohanning.github.io/assets/19912012/5ba9164b-004a-4b08-8fe3-7bf3e5e963b6" height="700" />
