### PR TITLE
Update dotnet.yml - pin dotnet-reportgenerator-globaltool to a version that supports .net 6

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -72,7 +72,7 @@ jobs:
 
     - name: Create code coverage report
       run: |
-        dotnet tool install -g dotnet-reportgenerator-globaltool
+        dotnet tool install -g dotnet-reportgenerator-globaltool --version 5.2.0
         reportgenerator -reports:coverage/*/coverage.cobertura.xml -targetdir:CodeCoverage -reporttypes:'MarkdownSummaryGithub;Cobertura'
 
     - name: Write to Job Summary


### PR DESCRIPTION
 error NU1202: Package dotnet-reportgenerator-globaltool 5.4.4 is not compatible with net6.0 (.NETCoreApp,Version=v6.0)